### PR TITLE
chkconfig ctdb for admin gridcells while first time setup

### DIFF
--- a/scripts/python/first_time_setup.py
+++ b/scripts/python/first_time_setup.py
@@ -33,14 +33,25 @@ def get_admin_gridcells():
       print '%d. %s'%(index, minion)
     print
 
-    str_to_print = 'Enter the number corresponding to one other GRIDCells from the above list that will act as admin GRIDCells : '
-
     valid_input = False
     while not valid_input:
       admin_server_list = []
+      num_admin_servers = None
+      try:
+        num_admin_servers = int(raw_input('How many additional admin GRIDCells required? '))
+        if (num_admin_servers > len(pending_minions)-1) or (num_admin_servers < 1):
+          raise Exception()
+        if not num_admin_servers:
+          raise Exception()
+      except Exception, e:
+        print 'Invalid input. Retry\n'
+        continue
+      print '%s additional admin GRIDCells will be provisioned'%num_admin_servers
+      str_to_print = 'Enter index-numbers corresponding to %s other GRIDCells from the above list that will act as admin GRIDCells: '%num_admin_servers
       input = raw_input(str_to_print)
       if input:
         try:
+          '''
           admin_server_index = int(input.strip())
         except Exception, e:
           print 'Please enter a valid number from the list above'
@@ -50,17 +61,16 @@ def get_admin_gridcells():
           continue
         admin_server_list.append(pending_minions[admin_server_index-1])
         '''
-        try:
           admin_server_index_list = [x.strip() for x in input.split(',')]
         except Exception, e:
           print "Invalid value. Please try again."
           continue
         #Check for uniqueness now
         if (len(admin_server_index_list) > len(set(admin_server_index_list))):
-          print "Please enter two distinct GRIDCell numbers."
+          print "Please enter %s distinct GRIDCell numbers."%num_admin_servers
           continue
-        if len(admin_server_index_list) != 2:
-          print "Please enter exactly two other GRIDCell numbers."
+        if len(admin_server_index_list) != num_admin_servers:
+          print "Please enter exactly %s other GRIDCell numbers."%num_admin_servers
           continue
         admin_server_list = []
         all_ok = True
@@ -76,7 +86,6 @@ def get_admin_gridcells():
           admin_server_list.append(pending_minions[admin_server_index-1])
         if not all_ok:
           continue
-        '''
         admin_server_list.append(me)
         print "\nThe following are the choices that you have made :"
         print

--- a/scripts/python/first_time_setup.py
+++ b/scripts/python/first_time_setup.py
@@ -553,6 +553,21 @@ def initiate_setup():
             errors = "Error restarting uwsgi service on %s"%node
             print errors
 
+    do = raw_input("Enable(chkconfig) services at startup?")
+    if do == 'y':
+      #Start CTDB, samba and/or winbind on the nodes..
+      print "Enabling services.."
+      rc, error = grid_ops.chkconfig_services(client, admin_gridcells, 'on')
+      if not rc:
+        e = None
+        if err:
+          e =  "Error enabling(chkconfig) services on the GRIDCells : %s"%err
+        else:
+          e =  "Error enabling(chkconfig) services on the GRIDCells"
+        raise Exception(e)
+      print "Enabling services.. Done."
+      print
+
     do = raw_input("Setup cron on the admin GRIDCells?")
     if do == 'y':
       print

--- a/site-packages/integralstor_gridcell/cifs.py
+++ b/site-packages/integralstor_gridcell/cifs.py
@@ -249,6 +249,9 @@ def _reload_config():
           errors += "Error reloading Windows services on GRIDCell %s "%node
     if errors:
       raise Exception(errors)
+    # restart winbind as a best-effort to prevent stale config; it could cause
+    # problems from Microsoft side otherwise.
+    r2 = client.cmd('*', 'cmd.run_all', ['service winbind restart'])
   except Exception, e:
     return False, 'Error reloading CIFS configuration: %s'%str(e)
   else:
@@ -419,6 +422,7 @@ def get_group_list():
     return ret, None
   
 def main():
+  print _reload_config()
   pass
 
 if __name__ == "__main__":

--- a/site-packages/integralstor_gridcell/grid_ops.py
+++ b/site-packages/integralstor_gridcell/grid_ops.py
@@ -663,7 +663,10 @@ def create_admin_volume(client, admin_gridcells):
     brick_list = ''
     for admin_gridcell in admin_gridcells:
       brick_list += ' %s:/frzpool/normal/%s'%(admin_gridcell, admin_vol_name)
-    cmd = "gluster --mode=script volume create %s repl 2  %s force --xml"%(admin_vol_name, brick_list)
+    if len(admin_gridcells) > 2:
+      cmd = "gluster --mode=script volume create %s repl 3 arbiter 1  %s force --xml"%(admin_vol_name, brick_list)
+    else:
+      cmd = "gluster --mode=script volume create %s repl 2  %s force --xml"%(admin_vol_name, brick_list)
     #print cmd
     #d, err = gluster_commands.run_gluster_command(cmd, "%s/create_volume.xml"%devel_files_path, "Admin volume creation")
     d, err = xml_parse.run_gluster_command(cmd)


### PR DESCRIPTION
We have not enabled ctdb(other services including smb & windbind) for any of the admin nodes while/after first_time_setup; we are enabling it after adding it to the storage pool, but that is only for those nodes that are being added through IntegralView. This code enables the service(s) for nodes added during first time setup.