### PR TITLE
Assert gluster admin vol access post mount

### DIFF
--- a/site-packages/integralstor_gridcell/grid_ops.py
+++ b/site-packages/integralstor_gridcell/grid_ops.py
@@ -905,6 +905,7 @@ def add_a_gridcell_to_storage_pool(si, hostname):
     return_dict = None
     try:
         error_list = []
+        hostname_list = []
         client = None
         ip = None
 
@@ -957,6 +958,9 @@ def add_a_gridcell_to_storage_pool(si, hostname):
             raise Exception(','.join(error_list))
         print 'added to the gluster storage pool.'
 
+        # sleep for 10 seconds to give time for gluster to go about its stuff
+        time.sleep(10)
+
         '''
     #print 'regenerating manifest and status.'
     rc, err = _regenerate_manifest_and_status(False)
@@ -979,6 +983,36 @@ def add_a_gridcell_to_storage_pool(si, hostname):
                 error_list.append(err)
             raise Exception(','.join(error_list))
         print 'Mounted admin volume.'
+
+        # Check if the admin vol mount actually succeded by reading a file from the admin volume
+        # Tries 3 times. Bail out if unsuccessfull
+        print "Check if mounted admin vol is accessible"
+        if rc is True:
+            iter = 3
+            while (iter):
+                iter -= 1
+                is_mount_ok = True
+                config_dir, err = config.get_config_dir()
+                if err:
+                    raise Exception(err)
+                ret = client.cmd(hostname, 'file.file_exists', [
+                    '%s/lock/assert_admin_vol_mount' % config_dir])
+                if ret:
+                    for node, val in ret.items():
+                        if val is False:
+                            print "Mounted vol not readable! Retrying after 5 seconds."
+                            is_mount_ok = False
+                            break
+
+                    if is_mount_ok is True:
+                        break
+                    else:
+                        time.sleep(5)
+            if iter < 1:
+                error_list.append("Admin volume mount failed!")
+                # Mount failed. Try to unmount as a best effort.
+                rc, err = unmount_admin_volume(client, [hostname])
+                raise Exception(','.join(error_list))
 
         print 'adding to ctdb nodes file.'
         rc, err = ctdb.add_to_nodes_file([ip])


### PR DESCRIPTION
Gluster mount vol call may return True but the volume may not have
been sucessfully mounted yet; ie, vol is mounted but not accessible.
Give some time for the volume to come up, only then proceed; bail out
if volume is not accessible after 3 tries(3 x 5 seconds)

- Sleep for 10 sec after peer probe while adding a node to the cluster

- Assert admin volume mount by reading a file from admin vol
  (assert_admin_vol_mount in ./confg/)

Signed-off-by: six-k <ramsri.hp@gmail.com>