### PR TITLE
Create DB during first time setup

### DIFF
--- a/install/ks/ksgridcell.cfg
+++ b/install/ks/ksgridcell.cfg
@@ -539,9 +539,4 @@ mv /var/lib/glusterd/hooks/1/stop/pre/S29CTDB-teardown.sh /var/lib/glusterd/hook
 mv /var/lib/glusterd/hooks/1/stop/pre/S30samba-stop.sh /var/lib/glusterd/hooks/1/stop/pre/unused_S30samba-stop.sh
 mv /var/lib/glusterd/hooks/1/set/post/S30samba-set.sh /var/lib/glusterd/hooks/1/set/post/unused_S30samba-set.sh
 
-cp -rf /opt/integralstor/integralstor_gridcell/defaults/db /opt/integralstor/integralstor_gridcell/config
-cd /opt/integralstor/integralstor_gridcell/config/db/
-rm -rf integral_view_config.db
-sqlite3 integral_view_config.db < integral_view_config.schema
-
 %end

--- a/scripts/python/first_time_setup.py
+++ b/scripts/python/first_time_setup.py
@@ -2,7 +2,6 @@
 import salt.wheel
 import sys
 import os
-import shutil
 import socket
 import struct
 import sys
@@ -163,8 +162,16 @@ def establish_default_configuration(client, si, admin_gridcells):
             raise Exception(err)
 
         print "\nCopying the default configuration onto the IntegralStor administration volume."
-
         shutil.copytree("%s/db" % defaults_dir, "%s/db" % config_dir)
+
+        # Create integral view DB
+        ret, err = command.get_command_output('rm -rf %s/db/integral_view_config.db' % config_dir, shell=True)
+        if err:
+            pass
+        ret, err = command.get_command_output('sqlite3 %s/db/integral_view_config.db < %s/db/integral_view_config.schema' % (config_dir,config_dir), shell=True)
+        if err:
+            raise Exception('Could not create DB: %s' % err)
+
         shutil.copytree("%s/ntp" % defaults_dir, "%s/ntp" % config_dir)
         shutil.copytree("%s/logs" % defaults_dir, "%s/logs" % config_dir)
 


### PR DESCRIPTION
DB should not be created at ../config/db/ during installation
since DB is placed in integralstor_admin_vol which is mounted
by all clustered nodes via gluster.

Previously, DB was created in KS and later gets overwritten by a call
in first_time_setup.py which puts in a stale copy from ../defaults/db/

  - Create DB on the fly during first_time_setup on the admin volume

Signed-off-by: six-k <ramsri.hp@gmail.com>